### PR TITLE
:sparkles: BuilderManager to support new block

### DIFF
--- a/src/Game/Blocks/Builds/MinerT1.cpp
+++ b/src/Game/Blocks/Builds/MinerT1.cpp
@@ -10,5 +10,5 @@ MinerT1::MinerT1() : AMiner()
 {
     _sprite = new sdf::Sprite(glm::vec3(0, 0, 0),
         sdf::GetterTextures::instance->getTexture("MinerT1"));
-    _speedMining = 1;
+    _speedMining = 2.5f;
 }

--- a/src/Game/Map/BuilderManager.hpp
+++ b/src/Game/Map/BuilderManager.hpp
@@ -17,6 +17,10 @@ class BuilderManager
             BUILD,
             DESTROY
         };
+        enum placementType {
+            FREE,
+            VEIN_ONLY,
+        };
     private:
         bool _isBase = true;
 
@@ -30,6 +34,7 @@ class BuilderManager
         std::vector<int> _keys;
         std::vector<int> _mouseKeys;
 
+        placementType _placementType = FREE;
     public:
         static BuilderManager *instance;
         BuilderManager();
@@ -48,7 +53,8 @@ class BuilderManager
         void setIsBase(bool isBase);
         bool get_isBuilding() const;
         void set_isBuilding(typeBuild isBuilding);
-        void buildBlock(GLFWwindow *window, MapGrid &map);
+        void buildBlockFree(GLFWwindow *window, MapGrid &map);
+        void buildBlockVein(GLFWwindow *window, MapGrid &map);
         void destroyBlock(GLFWwindow *window, MapGrid &map);
         void draw(sdf::Renderer &renderer);
         glm::vec2 getMousePos(GLFWwindow *window);


### PR DESCRIPTION
Adding new key bindings for different building types, introducing a new block type (`MinerT1`), and refactoring the block-building methods.

### Enhancements to Building Functionality:

* [`src/Game/Map/BuilderManager.cpp`](diffhunk://#diff-0d5acf61a3e06311a2cfd4a2fb74003fcd62c4677fa2e98a002d6ddb674060bdR63-R79): Added new key bindings (`GLFW_KEY_T` and `GLFW_KEY_M`) for different building types and updated the `updateBuildKeys` method to handle these new keys. Introduced `_placementType` to differentiate between free placement and vein-only placement. 

* [`src/Game/Map/BuilderManager.hpp`](diffhunk://#diff-b0e81347a58f9586a391d72eac3218229f2dc127c06bfa596efbf8431d160046R20-R23): Added a new `placementType` enum to handle different placement types and updated the `BuilderManager` class to include this new type.

### Introduction of New Block Type:

* [`src/Game/Blocks/Builds/MinerT1.cpp`](diffhunk://#diff-bdad524f056e395f347df797f614e6eec1c5eec51272cf72be984a1b169f1f58L13-R13): Modified the `MinerT1` constructor to increase the mining speed from 1 to 2.5.

### Refactoring of Block-Building Methods:

* [`src/Game/Map/BuilderManager.cpp`](diffhunk://#diff-0d5acf61a3e06311a2cfd4a2fb74003fcd62c4677fa2e98a002d6ddb674060bdL138-R153): Split the `buildBlock` method into `buildBlockFree` and `buildBlockVein` to handle different placement types. Updated the `getCopyBlockBuilding` method to support the new `MinerT1` block type. 
