### PR TITLE
:bug: Fix drawing logic in ATapis based on direction

### DIFF
--- a/src/Game/Blocks/Builds/Tapis/ATapis.cpp
+++ b/src/Game/Blocks/Builds/Tapis/ATapis.cpp
@@ -202,9 +202,14 @@ void ATapis::updatePosSprite()
 
 void ATapis::draw(sdf::Renderer &renderer)
 {
-    for (int i = _itemsTransitting.size() - 1; i >= 0; i--) {
-        std::get<1>(_itemsTransitting[i]).setLayer(i * 9 / 100 + 20);
-        std::get<1>(_itemsTransitting[i]).draw(renderer);
+    if (_direction == UP || _direction == RIGHT) {
+        for (int i = _itemsTransitting.size() - 1; i >= 0; i--) {
+            std::get<1>(_itemsTransitting[i]).draw(renderer);
+        }
+    }
+    if (_direction == DOWN || _direction == LEFT) {
+        for (int i = 0; i < _itemsTransitting.size(); i++)
+            std::get<1>(_itemsTransitting[i]).draw(renderer);
     }
     _sprite->draw(renderer);
 }


### PR DESCRIPTION
Modifies the drawing logic based on the direction of the `ATapis` object.

Drawing logic update:

* [`src/Game/Blocks/Builds/Tapis/ATapis.cpp`](diffhunk://#diff-70341ab93ee2e01d564d7419faec397603044036c84055580bcef4d5ed768699R205-R211): Updated the `ATapis::draw` method to handle different drawing orders based on the `_direction` attribute. Items are now drawn in reverse order if the direction is `UP` or `RIGHT`, and in normal order if the direction is `DOWN` or `LEFT`.