### PR TITLE
:sparkles: Refactor ATapis methods to include direction parameter for good transitions

### DIFF
--- a/src/Game/Blocks/Builds/Tapis/ATapis.hpp
+++ b/src/Game/Blocks/Builds/Tapis/ATapis.hpp
@@ -14,7 +14,7 @@ class ATapis : public ABuilds
     public:
         bool addElement(Item item) override;
         void setDirection(Direction direction) override;
-        bool addElementTapis(Item item);
+        bool addElementTapis(Item item, Direction direction);
         bool outElementTapis(std::string name, MapGrid map);
         void update(float deltaTime, MapGrid map) override;
         void updateTakeBehind(MapGrid map);
@@ -22,8 +22,12 @@ class ATapis : public ABuilds
         void updateAllItemsTransitting(float deltaTime);
         void updatePushItemFront(MapGrid map);
         void updatePosSprite();
+        void updatePosSpriteFirst(size_t i);
+        void updatePosSpriteSecond(size_t i);
+
         void draw(sdf::Renderer &renderer) override;
         Direction getDirection() const;
+        bool myAddElement(Item item, Direction direction);
     protected:
         ATapis();
         std::vector<std::tuple<float, Item, Direction>> _itemsTransitting;
@@ -33,6 +37,4 @@ class ATapis : public ABuilds
         float _travelTime; // duree pour un objet de parcourir le tapis
 
         int nbUpdate = 0;
-    private:
-        bool myAddElement(Item item);
 };


### PR DESCRIPTION
Adding a direction parameter to various methods, refactoring the position update logic, and modifying function signatures to accommodate the new parameter.

Enhancements to item direction handling:

* [`src/Game/Blocks/Builds/Tapis/ATapis.cpp`](diffhunk://#diff-70341ab93ee2e01d564d7419faec397603044036c84055580bcef4d5ed768699L12-R12): Updated the `addElement`, `myAddElement`, and `addElementTapis` methods to include a `Direction` parameter, allowing items to be added with a specified direction.

Refactoring of position update logic:

* [`src/Game/Blocks/Builds/Tapis/ATapis.cpp`](diffhunk://#diff-70341ab93ee2e01d564d7419faec397603044036c84055580bcef4d5ed768699L181-L191): Split the `updatePosSprite` method into `updatePosSpriteFirst` and `updatePosSpriteSecond` to handle different stages of item position updates based on their travel progress. This change improves code readability and maintainability.

Updates to class definition:

* [`src/Game/Blocks/Builds/Tapis/ATapis.hpp`](diffhunk://#diff-3dc1c86ee87ec42d9803966b7c63a64e0f1c0439140f9ad2cb0e368a26c0232bL17-R30): Modified the `ATapis` class definition to include the new `Direction` parameter in relevant methods and added declarations for the new position update methods.